### PR TITLE
Force JWT subject claim to string format

### DIFF
--- a/lib/warden/jwt_auth/payload_user_helper.rb
+++ b/lib/warden/jwt_auth/payload_user_helper.rb
@@ -30,7 +30,7 @@ module Warden
       # :reek:ManualDispatch
       def self.payload_for_user(user, scope)
         sub = user.jwt_subject
-        payload = { 'sub' => sub, 'scp' => scope.to_s }
+        payload = { 'sub' => sub.to_s, 'scp' => scope.to_s }
         return payload unless user.respond_to?(:jwt_payload)
         user.jwt_payload.merge(payload)
       end

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -8,7 +8,7 @@ module Fixtures
     include Singleton
 
     def jwt_subject
-      "1"
+      '1'
     end
 
     def jwt_payload

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -8,7 +8,7 @@ module Fixtures
     include Singleton
 
     def jwt_subject
-      1
+      "1"
     end
 
     def jwt_payload


### PR DESCRIPTION
As describe in the RFC 7519, the [sub](https://tools.ietf.org/html/rfc7519#section-4.1.2) field must be a string.

When using [devise-jwt](https://github.com/waiting-for-dev/devise-jwt) with MySQL, `Devise::Models::JwtAuthenticatable#jwt_subject` returns the integer ID of the model.


I encounter an error using [devise-jwt](https://github.com/waiting-for-dev/devise-jwt) in the server side and [jwt-go](https://github.com/dgrijalva/jwt-go) in the client side because there is a mismatch on `sub` field:

Encountered error in my Golang client:
```
json: cannot unmarshal number into Go struct field StandardClaims.sub of type string
```

Expected `jwt-go` claims format:
```go
// Structured version of Claims Section, as referenced at
// https://tools.ietf.org/html/rfc7519#section-4.1
// See examples for how to use this with your own claim types
type StandardClaims struct {
	Audience  string `json:"aud,omitempty"`
	ExpiresAt int64  `json:"exp,omitempty"`
	Id        string `json:"jti,omitempty"`
	IssuedAt  int64  `json:"iat,omitempty"`
	Issuer    string `json:"iss,omitempty"`
	NotBefore int64  `json:"nbf,omitempty"`
	Subject   string `json:"sub,omitempty"`
}
```
> https://github.com/dgrijalva/jwt-go/blob/master/claims.go#L15-L26