### PR TITLE
Convert env['PATH_INFO'] to string

### DIFF
--- a/lib/warden/jwt_auth/hooks.rb
+++ b/lib/warden/jwt_auth/hooks.rb
@@ -41,7 +41,7 @@ module Warden
       def request_matches?(env)
         dispatch_requests.each do |tuple|
           method, path = tuple
-          return true if env['PATH_INFO'].match(path) &&
+          return true if env['PATH_INFO'].to_s.match(path) &&
                          env['REQUEST_METHOD'] == method
         end
         false


### PR DESCRIPTION
Convert env['PATH_INFO'] to string so that match doesn't throw an error when its value is nil. Which is true in the case of writing feature tests.