### PR TITLE
Bump jwt to version ~> 2.1

### DIFF
--- a/spec/warden/jwt_auth/token_revoker_spec.rb
+++ b/spec/warden/jwt_auth/token_revoker_spec.rb
@@ -25,7 +25,7 @@ describe Warden::JWTAuth::TokenRevoker do
     end
 
     context 'when token is expired' do
-      before { Warden::JWTAuth.config.expiration_time = 0.01 }
+      before { Warden::JWTAuth.config.expiration_time = -1 }
 
       it 'silently ignores it' do
         expect { described_class.new.call(token) }.not_to raise_error

--- a/warden-jwt_auth.gemspec
+++ b/warden-jwt_auth.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'dry-configurable', '~> 0.5'
   spec.add_dependency 'dry-auto_inject', '~> 0.4'
-  spec.add_dependency 'jwt', '~> 1.5'
+  spec.add_dependency 'jwt', '~> 2.1'
   spec.add_dependency 'warden', '~> 1.2'
 
   spec.add_development_dependency "bundler", "~> 1.12"


### PR DESCRIPTION
2.0.0+ enforce an integer in the payload's exp parameter. One test used an expiration time of 0.01 to simulate an already-expired token, which triggered the raise added in jwt/ruby-jwt#205. A value of -1 accomplishes the same thing and allows the test to pass.