### PR TITLE
Setting nil PATH_INFO env variable to empty string

### DIFF
--- a/lib/warden/jwt_auth/hooks.rb
+++ b/lib/warden/jwt_auth/hooks.rb
@@ -39,9 +39,10 @@ module Warden
 
       # :reek:FeatureEnvy
       def request_matches?(env)
+        path_info = env['PATH_INFO'] || ''
         dispatch_requests.each do |tuple|
           method, path = tuple
-          return true if env['PATH_INFO'].match(path) &&
+          return true if path_info.match(path) &&
                          env['REQUEST_METHOD'] == method
         end
         false

--- a/lib/warden/jwt_auth/middleware/revocation_manager.rb
+++ b/lib/warden/jwt_auth/middleware/revocation_manager.rb
@@ -32,10 +32,11 @@ module Warden
 
         # :reek:FeatureEnvy
         def token_should_be_revoked?(env)
+          path_info = env['PATH_INFO'] || ''
           revocation_requests = config.revocation_requests
           revocation_requests.each do |tuple|
             method, path = tuple
-            return true if env['PATH_INFO'].match(path) &&
+            return true if path_info.match(path) &&
                            env['REQUEST_METHOD'] == method
           end
           false


### PR DESCRIPTION
Fixing issue referenced in https://github.com/waiting-for-dev/warden-jwt_auth/pull/8.

Request specs don't pass through a PATH_INFO environment variable which is causing an issue when attempting to call `match` on `nil`.