### PR TITLE
allow storing user repo / revocation strategy mappings as strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Currently, HS256 algorithm is the one in use.
 
 ### Warden scopes configuration
 
-You have to map the warden scopes that will be authenticatable through JWT, with the user repositories from where these scope user records can be fetched.
+You have to map the warden scopes that will be authenticatable through JWT, with the user repositories from where these scope user records can be fetched. If a string is supplied, the user repository will first be looked up as a constant.
 
 For instance:
 
@@ -142,7 +142,7 @@ config.revocation_requests = [
 
 **Important**: You are encouraged to delimit your regular expression with `^` and `$` to avoid unintentional matches.
 
-Besides, you need to configure which revocation strategy will be used for each scope.
+Besides, you need to configure which revocation strategy will be used for each scope. If a string is supplied, the revocation strategy will first be looked up as a constant.
 
 ```ruby
 config.revocation_strategies = { user: RevocationStrategy }

--- a/lib/warden/jwt_auth.rb
+++ b/lib/warden/jwt_auth.rb
@@ -25,7 +25,8 @@ module Warden
     # Expiration time for tokens
     setting :expiration_time, 3600
 
-    # A hash of warden scopes as keys and user repositories as values.
+    # A hash of warden scopes as keys and user repositories as values. The
+    # values can be either the constants themselves or the constant names.
     #
     # @see Interfaces::UserRepository
     # @see Interfaces::User
@@ -56,8 +57,9 @@ module Warden
       upcase_first_items(value)
     end
 
-    # Hash with scopes as keys and values with the strategy to revoke tokens for
-    # that scope
+    # Hash with scopes as keys and strategies to revoke tokens for that scope
+    # as values. The values can be either the constants themselves or the
+    # constant names.
     #
     # @example
     #  {
@@ -87,6 +89,23 @@ module Warden
     end
 
     Import = Dry::AutoInject(config)
+
+    config.instance_eval do
+      def mappings
+        constantize_values(super)
+      end
+
+      def revocation_strategies
+        constantize_values(super)
+      end
+
+      # :reek:UtilityFunction
+      def constantize_values(hash)
+        hash.transform_values do |value|
+          value.is_a?(String) ? Object.const_get(value) : value
+        end
+      end
+    end
   end
 end
 

--- a/lib/warden/jwt_auth.rb
+++ b/lib/warden/jwt_auth.rb
@@ -101,9 +101,8 @@ module Warden
 
       # :reek:UtilityFunction
       def constantize_values(hash)
-        hash.reduce({}) do |memo, (key, value)|
+        hash.each_with_object({}) do |(key, value), memo|
           memo[key] = value.is_a?(String) ? Object.const_get(value) : value
-          memo
         end
       end
     end

--- a/lib/warden/jwt_auth.rb
+++ b/lib/warden/jwt_auth.rb
@@ -101,8 +101,9 @@ module Warden
 
       # :reek:UtilityFunction
       def constantize_values(hash)
-        hash.transform_values do |value|
-          value.is_a?(String) ? Object.const_get(value) : value
+        hash.reduce({}) do |memo, (key, value)|
+          memo[key] = value.is_a?(String) ? Object.const_get(value) : value
+          memo
         end
       end
     end

--- a/spec/warden/jwt_auth_spec.rb
+++ b/spec/warden/jwt_auth_spec.rb
@@ -26,10 +26,10 @@ describe Warden::JWTAuth do
       context 'when the mapping is a constant name' do
         it 'resolves to the constant' do
           described_class.configure do |config|
-            config.mappings = { user: 'Fixtures::RevocationStrategy' }
+            config.revocation_strategies = { user: 'Fixtures::RevocationStrategy' }
           end
 
-          expect(described_class.config.mappings).to eq({
+          expect(described_class.config.revocation_strategies).to eq({
             user: Fixtures::RevocationStrategy
           })
         end

--- a/spec/warden/jwt_auth_spec.rb
+++ b/spec/warden/jwt_auth_spec.rb
@@ -6,4 +6,34 @@ describe Warden::JWTAuth do
   it 'has a version number' do
     expect(Warden::JWTAuth::VERSION).not_to be nil
   end
+
+  describe '#config' do
+    describe '#mappings' do
+      context 'when the mapping is a constant name' do
+        it 'resolves to the constant' do
+          described_class.configure do |config|
+            config.mappings = { user: 'Fixtures::UserRepo' }
+          end
+
+          expect(described_class.config.mappings).to eq({
+            user: Fixtures::UserRepo
+          })
+        end
+      end
+    end
+
+    describe '#revocation_strategies' do
+      context 'when the mapping is a constant name' do
+        it 'resolves to the constant' do
+          described_class.configure do |config|
+            config.mappings = { user: 'Fixtures::RevocationStrategy' }
+          end
+
+          expect(described_class.config.mappings).to eq({
+            user: Fixtures::RevocationStrategy
+          })
+        end
+      end
+    end
+  end
 end

--- a/spec/warden/jwt_auth_spec.rb
+++ b/spec/warden/jwt_auth_spec.rb
@@ -7,32 +7,34 @@ describe Warden::JWTAuth do
     expect(Warden::JWTAuth::VERSION).not_to be nil
   end
 
-  describe '#config' do
-    describe '#mappings' do
-      context 'when the mapping is a constant name' do
-        it 'resolves to the constant' do
-          described_class.configure do |config|
-            config.mappings = { user: 'Fixtures::UserRepo' }
-          end
-
-          expect(described_class.config.mappings).to eq({
-            user: Fixtures::UserRepo
-          })
+  describe '#config.mappings' do
+    context 'when the mapping is a constant name' do
+      before do
+        described_class.configure do |config|
+          config.mappings = { user: 'Fixtures::UserRepo' }
         end
       end
+
+      it 'resolves to the constant' do
+        expect(described_class.config.mappings).to eq(
+          user: Fixtures::UserRepo
+        )
+      end
     end
+  end
 
-    describe '#revocation_strategies' do
-      context 'when the mapping is a constant name' do
-        it 'resolves to the constant' do
-          described_class.configure do |config|
-            config.revocation_strategies = { user: 'Fixtures::RevocationStrategy' }
-          end
-
-          expect(described_class.config.revocation_strategies).to eq({
-            user: Fixtures::RevocationStrategy
-          })
+  describe '#config.revocation_strategies' do
+    context 'when the mapping is a constant name' do
+      before do
+        described_class.configure do |config|
+          config.revocation_strategies = { user: 'Fixtures::RevocationStrategy' }
         end
+      end
+
+      it 'resolves to the constant' do
+        expect(described_class.config.revocation_strategies).to eq(
+          user: Fixtures::RevocationStrategy
+        )
       end
     end
   end


### PR DESCRIPTION
implements the same feature as #5. would like to ultimately resolve https://github.com/waiting-for-dev/devise-jwt/issues/22 as it is a pain-point for us during development right now.

i added the constant lookup at the configuration layer (per your comments) to both the user repositories and the revocation strategies. dry-configurable defines its methods on the config object rather than the user's class, so i monkey patched the config rather than overriding any class methods.