### PR TITLE
Allow configuration of the algorithm to be used for encoding/decoding

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,3 +13,5 @@ Metrics/BlockLength:
     - "spec/**/*.rb"
 Metrics/LineLength:
   Max: 100
+Naming/RescuedExceptionsVariableName:
+  PreferredName: exception

--- a/README.md
+++ b/README.md
@@ -59,7 +59,14 @@ end
 
 **Important:** You are encouraged to use a dedicated secret key, different than others in use in your application. If several components share the same secret key, chances that a vulnerability in one of them has a wider impact increase. Also, never share your secrets pushing it to a remote repository, you are better off using an environment variable like in the example.
 
-Currently, HS256 algorithm is the one in use.
+Currently, HS256 algorithm is the default.
+Configure the matching secret and algorithm name to use a different one (e.g. RS256)
+```ruby
+Warden::JWTAuth.configure do |config|
+  config.secret = OpenSSL::PKey::RSA.new(ENV['WARDEN_JWT_SECRET_KEY'])
+  config.algorithm = ENV['WARDEN_JWT_ALGORITHM']
+end
+```
 
 ### Warden scopes configuration
 

--- a/lib/warden/jwt_auth.rb
+++ b/lib/warden/jwt_auth.rb
@@ -22,6 +22,9 @@ module Warden
     # The secret used to encode the token
     setting :secret
 
+    # The algorithm used to encode the token
+    setting :algorithm, 'HS256'
+
     # Expiration time for tokens
     setting :expiration_time, 3600
 

--- a/lib/warden/jwt_auth/token_decoder.rb
+++ b/lib/warden/jwt_auth/token_decoder.rb
@@ -4,7 +4,7 @@ module Warden
   module JWTAuth
     # Decodes a JWT into a hash payload into a JWT token
     class TokenDecoder
-      include JWTAuth::Import['secret']
+      include JWTAuth::Import['secret', 'algorithm']
 
       # Decodes the payload from a JWT as a hash
       #
@@ -17,7 +17,7 @@ module Warden
         JWT.decode(token,
                    secret,
                    true,
-                   algorithm: TokenEncoder::ALG,
+                   algorithm: algorithm,
                    verify_jti: true)[0]
       end
     end

--- a/lib/warden/jwt_auth/token_encoder.rb
+++ b/lib/warden/jwt_auth/token_encoder.rb
@@ -7,10 +7,7 @@ module Warden
     # Encodes a payload into a JWT token, adding some configurable
     # claims
     class TokenEncoder
-      include JWTAuth::Import['secret', 'expiration_time']
-
-      # Algorithm used to encode
-      ALG = 'HS256'
+      include JWTAuth::Import['secret', 'algorithm', 'expiration_time']
 
       # Encodes a payload into a JWT
       #
@@ -18,7 +15,7 @@ module Warden
       # @return [String] JWT
       def call(payload)
         payload_to_encode = merge_with_default_claims(payload)
-        JWT.encode(payload_to_encode, secret, ALG)
+        JWT.encode(payload_to_encode, secret, algorithm)
       end
 
       private

--- a/warden-jwt_auth.gemspec
+++ b/warden-jwt_auth.gemspec
@@ -1,35 +1,36 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+# frozen_string_literal: true
+
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'warden/jwt_auth/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "warden-jwt_auth"
+  spec.name          = 'warden-jwt_auth'
   spec.version       = Warden::JWTAuth::VERSION
-  spec.authors       = ["Marc Busqué"]
-  spec.email         = ["marc@lamarciana.com"]
+  spec.authors       = ['Marc Busqué']
+  spec.email         = ['marc@lamarciana.com']
 
-  spec.summary       = %q{JWT authentication for Warden.}
-  spec.description   = %q{JWT authentication for Warden, ORM agnostic and accepting the implementation of token revocation strategies.}
-  spec.homepage      = "https://github.com/waiting-for-dev/warden-jwt_auth"
-  spec.license       = "MIT"
+  spec.summary       = 'JWT authentication for Warden.'
+  spec.description   = 'JWT authentication for Warden, ORM agnostic and accepting the implementation of token revocation strategies.'
+  spec.homepage      = 'https://github.com/waiting-for-dev/warden-jwt_auth'
+  spec.license       = 'MIT'
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.bindir        = "exe"
+  spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.add_dependency 'dry-configurable', '~> 0.8'
   spec.add_dependency 'dry-auto_inject', '~> 0.6'
+  spec.add_dependency 'dry-configurable', '~> 0.8'
   spec.add_dependency 'jwt', '~> 2.1'
   spec.add_dependency 'warden', '~> 1.2'
 
-  spec.add_development_dependency "bundler"
-  spec.add_development_dependency "rake", "~> 12.3"
-  spec.add_development_dependency "rspec", "~> 3.8"
-  spec.add_development_dependency "rack-test", "~> 1.1"
-  spec.add_development_dependency "pry-byebug", "~> 3.7"
+  spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'pry-byebug', '~> 3.7'
+  spec.add_development_dependency 'rack-test', '~> 1.1'
+  spec.add_development_dependency 'rake', '~> 12.3'
+  spec.add_development_dependency 'rspec', '~> 3.8'
   # Test reporting
-  spec.add_development_dependency 'simplecov', '~> 0.16'
   spec.add_development_dependency 'codeclimate-test-reporter', '~> 1.0'
+  spec.add_development_dependency 'simplecov', '~> 0.16'
 end


### PR DESCRIPTION
Allow the use of different signing algorithm when encoding/decoding JWTs.

HS256 is currently hard coded for the encoding and decoding of the token.
This is a proposition to allow overriding the default and specify more robust (in particular RS256) algorithms.

Please tell me if there is any coding style/formatting issues or comment on this approach.