### PR TITLE
Fix class reload (when cache classes is disabled)

### DIFF
--- a/lib/warden/jwt_auth/payload_user_helper.rb
+++ b/lib/warden/jwt_auth/payload_user_helper.rb
@@ -11,8 +11,8 @@ module Warden
       def self.find_user(payload)
         config = JWTAuth.config
         scope = payload['scp'].to_sym
-        user_repo = config.mappings[scope]
-        user_repo.find_for_jwt_authentication(payload['sub'])
+        ref = config.mappings[scope].to_s.classify
+        Object.const_get(ref).find_for_jwt_authentication(payload['sub'])
       end
 
       # Returns whether given scope matches with the one encoded in the payload


### PR DESCRIPTION
**Problem:** `config.mappings [scope]` caches its state when the application starts.
**Description:** When we try to check an instance of a class, we will always (after reloading the code) receive `false` (example: `config.mappings [scope].is_a?(User) #=> false`)