### PR TITLE
feat: use Zeitwerk to load gem structure

### DIFF
--- a/lib/warden/jwt_auth.rb
+++ b/lib/warden/jwt_auth.rb
@@ -4,6 +4,7 @@ require 'dry/configurable'
 require 'dry/auto_inject'
 require 'jwt'
 require 'warden'
+require 'zeitwerk'
 
 module Warden
   # JWT authentication plugin for warden.
@@ -104,16 +105,11 @@ module Warden
   end
 end
 
-require 'warden/jwt_auth/version'
-require 'warden/jwt_auth/header_parser'
-require 'warden/jwt_auth/payload_user_helper'
-require 'warden/jwt_auth/env_helper'
-require 'warden/jwt_auth/user_encoder'
-require 'warden/jwt_auth/user_decoder'
-require 'warden/jwt_auth/token_encoder'
-require 'warden/jwt_auth/token_decoder'
-require 'warden/jwt_auth/token_revoker'
-require 'warden/jwt_auth/hooks'
-require 'warden/jwt_auth/strategy'
-require 'warden/jwt_auth/middleware'
-require 'warden/jwt_auth/interfaces'
+Zeitwerk::Loader.new.tap do |loader|
+  loader.tag = File.basename(__FILE__, ".rb")
+  loader.inflector = Zeitwerk::GemInflector.new(__FILE__)
+  loader.inflector.inflect('jwt_auth' => 'JWTAuth')
+  loader.push_dir("#{__dir__}/..")
+  loader.setup
+  loader.eager_load
+end

--- a/lib/warden/jwt_auth/middleware.rb
+++ b/lib/warden/jwt_auth/middleware.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'warden/jwt_auth/middleware/token_dispatcher'
-require 'warden/jwt_auth/middleware/revocation_manager'
-
 module Warden
   module JWTAuth
     # Simple rack middleware which is just a wrapper for other middlewares which

--- a/lib/warden/jwt_auth/strategy.rb
+++ b/lib/warden/jwt_auth/strategy.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'warden'
-
 module Warden
   module JWTAuth
     # Warden strategy to authenticate an user through a JWT token in the

--- a/lib/warden/jwt_auth/user_decoder.rb
+++ b/lib/warden/jwt_auth/user_decoder.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'warden/jwt_auth/errors'
-
 module Warden
   module JWTAuth
     # Layer above token decoding which directly decodes a user from a JWT

--- a/lib/warden/jwt_auth/user_encoder.rb
+++ b/lib/warden/jwt_auth/user_encoder.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'warden/jwt_auth/errors'
-
 module Warden
   module JWTAuth
     # Layer above token encoding which directly encodes a user to a JWT

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'warden/jwt_auth'
 require 'pry-byebug'
 require 'simplecov'

--- a/warden-jwt_auth.gemspec
+++ b/warden-jwt_auth.gemspec
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-lib = File.expand_path('lib', __dir__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'warden/jwt_auth/version'
+require_relative 'lib/warden/jwt_auth/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'warden-jwt_auth'
@@ -15,15 +13,14 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/waiting-for-dev/warden-jwt_auth'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.bindir        = 'exe'
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.files         = Dir.glob('lib/**/*')
+  spec.files        += %w[README.md LICENSE.txt warden-jwt_auth.gemspec]
   spec.require_paths = ['lib']
 
   spec.metadata['rubygems_mfa_required'] = 'true'
 
-  spec.add_dependency 'dry-auto_inject', '~> 0.8'
-  spec.add_dependency 'dry-configurable', '~> 0.13'
+  spec.add_dependency 'dry-auto_inject', '~> 1.0'
+  spec.add_dependency 'dry-configurable', '~> 1.0'
   spec.add_dependency 'jwt', '~> 2.1'
   spec.add_dependency 'warden', '~> 1.2'
 


### PR DESCRIPTION
dry-rb use zeitwerk as loader starting from version 1.0.0

I leveraged it usage to make it work in this gem.