### PR TITLE
Relax dry-rb dependencies

### DIFF
--- a/warden-jwt_auth.gemspec
+++ b/warden-jwt_auth.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |spec|
 
   spec.metadata['rubygems_mfa_required'] = 'true'
 
-  spec.add_dependency 'dry-auto_inject', '~> 0.8'
-  spec.add_dependency 'dry-configurable', '~> 0.13'
+  spec.add_dependency 'dry-auto_inject', '< 2'
+  spec.add_dependency 'dry-configurable', '< 2'
   spec.add_dependency 'jwt', '~> 2.1'
   spec.add_dependency 'warden', '~> 1.2'
 


### PR DESCRIPTION
## Summary

Relax dry-rb libs:
- dry-auto_inject: https://github.com/dry-rb/dry-auto_inject/blob/main/CHANGELOG.md
- dry-configurable: https://github.com/dry-rb/dry-configurable/blob/main/CHANGELOG.md

No breaking changes, tested locally and looks fine after upgrading to newest versions
