### PR TITLE
Add support for secret rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,19 @@ Authentication will be refused if a client requesting to be authenticated throug
 
 **Important:** Be aware that this workflow is not bullet proof. In some scenarios a user can handcraft the request headers, therefore being able to impersonate any client. In such cases you could need something more robust, like an OAuth workflow with client id and client secret.
 
+### Secret rotation
+
+Secret rotation is supported by setting `rotation_secret`. Set the new secret as the `secret` and copy the previous secret to `rotation_secret`
+
+```ruby
+Warden::JWTAuth.configure do |config|
+  config.secret = ENV['WARDEN_JWT_SECRET_KEY']
+  config.rotation_secret = ENV['WARDEN_JWT_SECRET_KEY_ROTATION']
+end
+```
+
+You can remove the `rotation_secret` when you are condifent that large enough user base has the fetched the token encrypted with the new secret.
+
 ## Development
 
 There are docker and docker-compose files configured to create a development environment for this gem. So, if you use Docker you only need to run:

--- a/lib/warden/jwt_auth.rb
+++ b/lib/warden/jwt_auth.rb
@@ -42,7 +42,7 @@ module Warden
     setting :secret
 
     # The old secret used for rotation
-    setting :secret_rotation
+    setting :rotation_secret
 
     # The secret used to decode the token, defaults to `secret` if not provided
     setting :decoding_secret, constructor: ->(value) { value || config.secret }

--- a/lib/warden/jwt_auth.rb
+++ b/lib/warden/jwt_auth.rb
@@ -41,6 +41,9 @@ module Warden
     # The secret used to encode the token
     setting :secret
 
+    # The old secret used for rotation
+    setting :secret_rotation
+
     # The secret used to decode the token, defaults to `secret` if not provided
     setting :decoding_secret, constructor: ->(value) { value || config.secret }
 

--- a/lib/warden/jwt_auth/token_decoder.rb
+++ b/lib/warden/jwt_auth/token_decoder.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
+require "jwt/error"
+
 module Warden
   module JWTAuth
     # Decodes a JWT into a hash payload into a JWT token
     class TokenDecoder
-      include JWTAuth::Import['decoding_secret', 'algorithm']
+      include JWTAuth::Import['decoding_secret', 'secret_rotation', 'algorithm']
 
       # Decodes the payload from a JWT as a hash
       #
@@ -14,11 +16,19 @@ module Warden
       # @param token [String] a JWT
       # @return [Hash] payload decoded from the JWT
       def call(token)
-        JWT.decode(token,
-                   decoding_secret,
-                   true,
-                   algorithm: algorithm,
-                   verify_jti: true)[0]
+        begin
+          JWT.decode(token,
+                     decoding_secret,
+                     true,
+                     algorithm: algorithm,
+                     verify_jti: true)[0]
+        rescue JWT::VerificationError => e
+          JWT.decode(token,
+                     secret_rotation,
+                     true,
+                     algorithm: algorithm,
+                     verify_jti: true)[0]
+        end
       end
     end
   end

--- a/lib/warden/jwt_auth/token_decoder.rb
+++ b/lib/warden/jwt_auth/token_decoder.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-require "jwt/error"
+require 'jwt/error'
 
 module Warden
   module JWTAuth
     # Decodes a JWT into a hash payload into a JWT token
     class TokenDecoder
-      include JWTAuth::Import['decoding_secret', 'secret_rotation', 'algorithm']
+      include JWTAuth::Import['decoding_secret', 'rotation_secret', 'algorithm']
 
       # Decodes the payload from a JWT as a hash
       #
@@ -16,19 +16,19 @@ module Warden
       # @param token [String] a JWT
       # @return [Hash] payload decoded from the JWT
       def call(token)
-        begin
-          JWT.decode(token,
-                     decoding_secret,
-                     true,
-                     algorithm: algorithm,
-                     verify_jti: true)[0]
-        rescue JWT::VerificationError => e
-          JWT.decode(token,
-                     secret_rotation,
-                     true,
-                     algorithm: algorithm,
-                     verify_jti: true)[0]
-        end
+        decode(token, decoding_secret)
+      rescue JWT::VerificationError
+        decode(token, rotation_secret)
+      end
+
+      private
+
+      def decode(token, secret)
+        JWT.decode(token,
+                   secret,
+                   true,
+                   algorithm: algorithm,
+                   verify_jti: true)[0]
       end
     end
   end

--- a/spec/support/shared_contexts/configuration.rb
+++ b/spec/support/shared_contexts/configuration.rb
@@ -4,6 +4,7 @@ shared_context 'configuration' do
   before do
     Warden::JWTAuth.configure do |config|
       config.secret = '123'
+      config.rotation_secret = '456'
       config.decoding_secret = '123'
       config.algorithm = 'HS256'
       config.dispatch_requests = [['POST', %r{^/sign_in$}]]
@@ -16,6 +17,7 @@ shared_context 'configuration' do
 
   let(:config) { Warden::JWTAuth.config }
   let(:secret) { config.secret }
+  let(:rotation_secret) { config.rotation_secret }
   let(:decoding_secret) { config.decoding_secret }
   let(:algorithm) { config.algorithm }
   let(:dispatch_requests) { config.dispatch_requests }

--- a/spec/warden/jwt_auth/token_decoder_spec.rb
+++ b/spec/warden/jwt_auth/token_decoder_spec.rb
@@ -9,14 +9,22 @@ describe Warden::JWTAuth::TokenDecoder do
     let(:payload) { { 'sub' => '1', 'jti' => '123' } }
     let(:token) { ::JWT.encode(payload, secret, 'HS256') }
     let(:rotated_token) { ::JWT.encode(payload, rotation_secret, 'HS256') }
+    let(:invalid_token) { ::JWT.encode(payload, 'invalid', 'HS256') }
 
     it 'returns the payload encoded in the token' do
       expect(described_class.new.call(token)).to eq(payload)
     end
 
-    it 'returns the payload encoded in the token when its rotated' do
-      expect(described_class.new.call(rotated_token)).to eq(payload)
+    it 'raises an error if decode fails' do
+      expect { described_class.new.call(invalid_token) }.to raise_error(JWT::VerificationError)
     end
 
+    it 'raises an error if no secret is set' do
+      expect { described_class.new.call(nil) }.to raise_error(JWT::DecodeError)
+    end
+
+    it 'returns the payload encoded in the token when it\'s rotated' do
+      expect(described_class.new.call(rotated_token)).to eq(payload)
+    end
   end
 end

--- a/spec/warden/jwt_auth/token_decoder_spec.rb
+++ b/spec/warden/jwt_auth/token_decoder_spec.rb
@@ -8,9 +8,15 @@ describe Warden::JWTAuth::TokenDecoder do
   describe '#call(token)' do
     let(:payload) { { 'sub' => '1', 'jti' => '123' } }
     let(:token) { ::JWT.encode(payload, secret, 'HS256') }
+    let(:rotated_token) { ::JWT.encode(payload, rotation_secret, 'HS256') }
 
     it 'returns the payload encoded in the token' do
       expect(described_class.new.call(token)).to eq(payload)
     end
+
+    it 'returns the payload encoded in the token when its rotated' do
+      expect(described_class.new.call(rotated_token)).to eq(payload)
+    end
+
   end
 end


### PR DESCRIPTION
## Summary

Adds support for secret rotation. Allows setting a secondary secret that is also accepted when decoing the token.

How it works:

1. Update the `secret` to a new value
2. Set the `rotation_secret` to the value of the previous secret
3. Profit

This has been used succesfully in a Rails 7.0 project in production.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [X] I have written a thorough PR description.
- [X] I have kept my commits small and atomic.
- [X] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [x] I have added automated tests to cover my changes.
~- [ ] I have attached screenshots to demo visual changes.~
~- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- [X] I have updated the README to account for my changes.
