### PR TITLE
Relax dependencies on dry-* gems

### DIFF
--- a/warden-jwt_auth.gemspec
+++ b/warden-jwt_auth.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |spec|
 
   spec.metadata['rubygems_mfa_required'] = 'true'
 
-  spec.add_dependency 'dry-auto_inject', '~> 0.8'
-  spec.add_dependency 'dry-configurable', '~> 0.13'
+  spec.add_dependency 'dry-auto_inject', '>= 0.8', '< 2'
+  spec.add_dependency 'dry-configurable', '>= 0.13', '< 2'
   spec.add_dependency 'jwt', '~> 2.1'
   spec.add_dependency 'warden', '~> 1.2'
 


### PR DESCRIPTION
## Summary

Hi! First of all, thank you for your work on this repo, it's super appreciated!

We've been updating some of our dependencies and found that the current constraints for the `dry-auto_inject` and `dry-configurable` gems are stricter then they need to be. Both gems recently released `1.x` versions, and those to seem to work great. This PR relaxes those constraints to make warden-jwt_auth compatible with these newer versions.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [ ] ~I have added automated tests to cover my changes.~
- [ ] ~I have attached screenshots to demo visual changes.~
- [ ] ~I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- [ ] ~I have updated the README to account for my changes.~
