### PR TITLE
Add support for configurable token header

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ config.dispatch_requests = [
 
 **Important**: You are encouraged to delimit your regular expression with `^` and `$` to avoid unintentional matches.
 
-Tokens will be returned in the `Authorization` response header, with format `Bearer #{token}`.
+Tokens will be returned in the `Authorization` response header (configurable via `config.token_header`), with format `Bearer #{token}`.
 
 ### Requests authentication
 

--- a/lib/warden/jwt_auth.rb
+++ b/lib/warden/jwt_auth.rb
@@ -50,6 +50,9 @@ module Warden
     # Expiration time for tokens
     setting :expiration_time, default: 3600
 
+    # Request header that will be used for receiving and returning the token.
+    setting :token_header, default: 'Authorization'
+
     # Request header which value will be encoded as `aud` claim in JWT. If
     # the header is not present `aud` will be `nil`.
     setting :aud_header, default: 'JWT_AUD'

--- a/lib/warden/jwt_auth/env_helper.rb
+++ b/lib/warden/jwt_auth/env_helper.rb
@@ -25,16 +25,17 @@ module Warden
         env['REQUEST_METHOD']
       end
 
-      # Returns HTTP_AUTHORIZATION environment variable
+      # Returns header configured through `token_header` option
       #
       # @param env [Hash] Rack env
       # @return [String]
       def self.authorization_header(env)
-        env['HTTP_AUTHORIZATION']
+        env_name = ('HTTP_' + JWTAuth.config.token_header.upcase).tr('-', '_')
+        env[env_name]
       end
 
-      # Returns a copy of `env` with value added to the `HTTP_AUTHORIZATION`
-      # environment variable.
+      # Returns a copy of `env` with value added to the environment variable
+      # configured through `token_header` option
       #
       # Be aware than `env` is not modified in place and still an updated copy
       # is returned.
@@ -44,7 +45,8 @@ module Warden
       # @return [Hash] modified rack env
       def self.set_authorization_header(env, value)
         env = env.dup
-        env['HTTP_AUTHORIZATION'] = value
+        env_name = ('HTTP_' + JWTAuth.config.token_header.upcase).tr('-', '_')
+        env[env_name] = value
         env
       end
 

--- a/lib/warden/jwt_auth/header_parser.rb
+++ b/lib/warden/jwt_auth/header_parser.rb
@@ -21,8 +21,8 @@ module Warden
         method == METHOD ? token : nil
       end
 
-      # Returns a copy of `env` with token added to the `HTTP_AUTHORIZATION`
-      # header. Be aware than `env` is not modified in place.
+      # Returns a copy of `env` with token added to the header configured through
+      # `token_header` option. Be aware than `env` is not modified in place.
       #
       # @param env [Hash] rack env hash
       # @param token [String] JWT token

--- a/lib/warden/jwt_auth/header_parser.rb
+++ b/lib/warden/jwt_auth/header_parser.rb
@@ -39,7 +39,7 @@ module Warden
       # @return [Hash] response headers with the token added
       def self.to_headers(headers, token)
         headers = headers.dup
-        headers['Authorization'] = "#{METHOD} #{token}"
+        headers[JWTAuth.config.token_header] = "#{METHOD} #{token}"
         headers
       end
     end

--- a/spec/warden/jwt_auth/env_helper_spec.rb
+++ b/spec/warden/jwt_auth/env_helper_spec.rb
@@ -23,15 +23,25 @@ describe Warden::JWTAuth::EnvHelper do
     it 'returns REQUEST_METHOD' do
       env = { 'REQUEST_METHOD' => 'POST' }
 
-      expect(described_class.request_method(env)) == 'POST'
+      expect(described_class.request_method(env)).to eq('POST')
     end
   end
 
   describe '::authorization_header(env)' do
-    it 'returns HTTP_AUTHORIZATION' do
+    it 'returns HTTP_AUTHORIZATION by default' do
       env = { 'HTTP_AUTHORIZATION' => 'Bearer 123' }
 
-      expect(described_class.authorization_header(env)) == 'Bearer 123'
+      expect(described_class.authorization_header(env)).to eq('Bearer 123')
+    end
+
+    describe 'custom token header' do
+      it 'returns configured token_header' do
+        allow(Warden::JWTAuth.config).to receive(:token_header).and_return('TEST_AUTHORIZATION')
+
+        env = { 'HTTP_TEST_AUTHORIZATION' => 'Bearer 123' }
+
+        expect(described_class.authorization_header(env)).to eq('Bearer 123')
+      end
     end
   end
 
@@ -42,6 +52,18 @@ describe Warden::JWTAuth::EnvHelper do
       updated_env = described_class.set_authorization_header(env, 'Bearer 123')
 
       expect(updated_env['HTTP_AUTHORIZATION']).to eq('Bearer 123')
+    end
+
+    describe 'custom token header' do
+      it 'sets value as configured token_header' do
+        allow(Warden::JWTAuth.config).to receive(:token_header).and_return('TEST_AUTHORIZATION')
+
+        env = {}
+
+        updated_env = described_class.set_authorization_header(env, 'Bearer 123')
+
+        expect(updated_env['HTTP_TEST_AUTHORIZATION']).to eq('Bearer 123')
+      end
     end
   end
 

--- a/spec/warden/jwt_auth/env_helper_spec.rb
+++ b/spec/warden/jwt_auth/env_helper_spec.rb
@@ -36,7 +36,7 @@ describe Warden::JWTAuth::EnvHelper do
 
     describe 'custom token header' do
       it 'returns configured token_header' do
-        allow(Warden::JWTAuth.config).to receive(:token_header).and_return('TEST_AUTHORIZATION')
+        allow(Warden::JWTAuth.config).to receive(:token_header).and_return('Test_Authorization')
 
         env = { 'HTTP_TEST_AUTHORIZATION' => 'Bearer 123' }
 
@@ -56,7 +56,7 @@ describe Warden::JWTAuth::EnvHelper do
 
     describe 'custom token header' do
       it 'sets value as configured token_header' do
-        allow(Warden::JWTAuth.config).to receive(:token_header).and_return('TEST_AUTHORIZATION')
+        allow(Warden::JWTAuth.config).to receive(:token_header).and_return('Test_Authorization')
 
         env = {}
 

--- a/spec/warden/jwt_auth/header_parser_spec.rb
+++ b/spec/warden/jwt_auth/header_parser_spec.rb
@@ -55,5 +55,18 @@ describe Warden::JWTAuth::HeaderParser do
 
       expect(headers).to eq('Authorization' => 'Bearer 123')
     end
+
+
+    describe 'custom token header' do
+      it 'returns configured token_header' do
+        allow(Warden::JWTAuth.config).to receive(:token_header).and_return('Test_Authorization')
+
+        headers = {}
+
+        headers = described_class.to_headers(headers, '123')
+
+        expect(headers).to eq('Test_Authorization' => 'Bearer 123')
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Adds the ability to change the header that the JWT token is sent & received through.

This has been in use in conjunction with an update to devise-jwt (will open PR if this one is approved) in a production application for more than 1 year without issue.

**Why it was needed**
When implementing devise-jwt to my platform, an issue was encountered with the 'Authorization' header always being used to transmit the JWT token. This is due to testing environments that use basic HTTP authentication, in which the 'Authorization' header is used for this authentication.
This update allowed us to use a different header in our testing environments to avoid conflicting.

**How it works**
If you need a custom header for a reason like the above, set the token_header configuration option. If you do not set an option, it will default to 'Authorization' and so will not affect existing implementations.


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [x] I have added automated tests to cover my changes.
~~- [ ] I have attached screenshots to demo visual changes.~~
~~- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~~
- [x] I have updated the README to account for my changes.
