### PR TITLE
Support Issuer claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ module RevocationStrategy
   def self.jwt_revoked?(payload, user)
     # Does something to check whether the JWT token is revoked for given user
   end
-  
+
   def self.revoke_jwt(payload, user)
     # Does something to revoke the JWT token for given user
   end
@@ -207,6 +207,17 @@ end
 ```
 
 You can remove the `rotation_secret` when you are condifent that large enough user base has the fetched the token encrypted with the new secret.
+
+### Multiple issuers
+
+When your application handles JWT tokens from multiple sources (e.g. webhooks authenticated via provider JTW tokens) you can configure this gem to use the [issuer claim](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.1) to only handle tokens it has issued.
+
+```ruby
+Warden::JWTAuth.configure do |config|
+  config.secret = ENV['WARDEN_JWT_SECRET_KEY']
+  config.issuer = 'http://my-application.com'
+end
+```
 
 ## Development
 

--- a/lib/warden/jwt_auth.rb
+++ b/lib/warden/jwt_auth.rb
@@ -53,6 +53,13 @@ module Warden
     # Expiration time for tokens
     setting :expiration_time, default: 3600
 
+    # The issuer claims associated with the tokens
+    #
+    # Will be used to only apply the warden strategy when the issuer matches.
+    # This allows for multiple token issuers being used.
+    # @see https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.1
+    setting :issuer, default: nil
+
     # Request header which value will be encoded as `aud` claim in JWT. If
     # the header is not present `aud` will be `nil`.
     setting :aud_header, default: 'JWT_AUD'

--- a/lib/warden/jwt_auth/payload_user_helper.rb
+++ b/lib/warden/jwt_auth/payload_user_helper.rb
@@ -29,6 +29,13 @@ module Warden
         payload['aud'] == aud
       end
 
+      # Returns whether given issuer matches with the one encoded in the payload
+      # @param payload [Hash] JWT payload
+      # @return [Boolean]
+      def self.issuer_matches?(payload, issuer)
+        payload['iss'] == issuer.to_s
+      end
+
       # Returns the payload to encode for a given user in a scope
       #
       # @param user [Interfaces::User] an user, whatever it is

--- a/lib/warden/jwt_auth/payload_user_helper.rb
+++ b/lib/warden/jwt_auth/payload_user_helper.rb
@@ -31,6 +31,7 @@ module Warden
 
       # Returns whether given issuer matches with the one encoded in the payload
       # @param payload [Hash] JWT payload
+      # @param issuer [String] The issuer to match
       # @return [Boolean]
       def self.issuer_matches?(payload, issuer)
         payload['iss'] == issuer.to_s

--- a/lib/warden/jwt_auth/strategy.rb
+++ b/lib/warden/jwt_auth/strategy.rb
@@ -8,7 +8,9 @@ module Warden
     # `Authorization` request header
     class Strategy < Warden::Strategies::Base
       def valid?
-        !token.nil?
+        !token.nil? && verify_issuer_claim
+      rescue JWT::DecodeError
+        true
       end
 
       def store?
@@ -27,6 +29,14 @@ module Warden
 
       def token
         @token ||= HeaderParser.from_env(env)
+      end
+
+      def verify_issuer_claim
+        case Warden::JWTAuth.config.issuer
+        when nil then true
+        when TokenDecoder.new.call(token)['iss'] then true
+        else false
+        end
       end
     end
   end

--- a/lib/warden/jwt_auth/strategy.rb
+++ b/lib/warden/jwt_auth/strategy.rb
@@ -40,7 +40,7 @@ module Warden
       end
 
       def issuer_claim_matches?
-        Warden::JWTAuth.config.issuer == TokenDecoder.new.call(token)['iss']
+        PayloadUserHelper.issuer_matches?(TokenDecoder.new.call(token), Warden::JWTAuth.config.issuer)
       end
     end
   end

--- a/lib/warden/jwt_auth/token_encoder.rb
+++ b/lib/warden/jwt_auth/token_encoder.rb
@@ -7,7 +7,7 @@ module Warden
     # Encodes a payload into a JWT token, adding some configurable
     # claims
     class TokenEncoder
-      include JWTAuth::Import['secret', 'algorithm', 'expiration_time']
+      include JWTAuth::Import['secret', 'algorithm', 'expiration_time', 'issuer']
 
       # Encodes a payload into a JWT
       #
@@ -24,6 +24,7 @@ module Warden
         now = Time.now.to_i
         payload['iat'] ||= now
         payload['exp'] ||= now + expiration_time
+        payload['iss'] ||= issuer if issuer
         payload['jti'] ||= SecureRandom.uuid
         payload
       end

--- a/spec/warden/jwt_auth/payload_user_helper_spec.rb
+++ b/spec/warden/jwt_auth/payload_user_helper_spec.rb
@@ -50,6 +50,24 @@ describe Warden::JWTAuth::PayloadUserHelper do
     end
   end
 
+  describe '::issuer_matches?(payload, aud)' do
+    context 'when given iss matches the one encoded in payload' do
+      it 'returns true' do
+        payload = { 'iss' => 'http://example.com' }
+
+        expect(described_class.issuer_matches?(payload, 'http://example.com')).to eq(true)
+      end
+    end
+
+    context 'when given iss does not match the one encoded in payload' do
+      it 'returns false' do
+        payload = { 'iss' => 'unknown' }
+
+        expect(described_class.issuer_matches?(payload, 'http://example.com')).to eq(false)
+      end
+    end
+  end
+
   describe '::payload_for_user(user, scope)' do
     let(:payload) { described_class.payload_for_user(user, :user) }
 

--- a/spec/warden/jwt_auth/strategy_spec.rb
+++ b/spec/warden/jwt_auth/strategy_spec.rb
@@ -35,6 +35,7 @@ describe Warden::JWTAuth::Strategy do
       let(:token) { Warden::JWTAuth::TokenEncoder.new.call({issuer: issuer}) }
       let(:env) { { 'HTTP_AUTHORIZATION' => "Bearer #{token}" } }
       let(:issuer) { 'http://example.com' }
+      let(:strategy) { described_class.new(env, :user) }
 
       before do
         Warden::JWTAuth.configure do |config|
@@ -44,8 +45,6 @@ describe Warden::JWTAuth::Strategy do
 
       context "when the issuer claim matches the configured issuer" do
         it 'returns true' do
-          strategy = described_class.new(env, :user)
-
           expect(strategy).to be_valid
         end
       end
@@ -54,8 +53,6 @@ describe Warden::JWTAuth::Strategy do
         let(:token) { Warden::JWTAuth::TokenEncoder.new.call({"iss" => 'http://example.org'}) }
 
         it 'returns false' do
-          strategy = described_class.new(env, :user)
-
           expect(strategy).not_to be_valid
         end
       end

--- a/spec/warden/jwt_auth/strategy_spec.rb
+++ b/spec/warden/jwt_auth/strategy_spec.rb
@@ -30,6 +30,36 @@ describe Warden::JWTAuth::Strategy do
         expect(strategy).not_to be_valid
       end
     end
+
+    context "when issuer is configured" do
+      let(:token) { Warden::JWTAuth::TokenEncoder.new.call({issuer: issuer}) }
+      let(:env) { { 'HTTP_AUTHORIZATION' => "Bearer #{token}" } }
+      let(:issuer) { 'http://example.com' }
+
+      before do
+        Warden::JWTAuth.configure do |config|
+          config.issuer = issuer
+        end
+      end
+
+      context "when the issuer claim matches the configured issuer" do
+        it 'returns true' do
+          strategy = described_class.new(env, :user)
+
+          expect(strategy).to be_valid
+        end
+      end
+
+      context "when the issuer claim does not match the configured issuer" do
+        let(:token) { Warden::JWTAuth::TokenEncoder.new.call({"iss" => 'http://example.org'}) }
+
+        it 'returns false' do
+          strategy = described_class.new(env, :user)
+
+          expect(strategy).not_to be_valid
+        end
+      end
+    end
   end
 
   describe '#persist?' do

--- a/spec/warden/jwt_auth/token_encoder_spec.rb
+++ b/spec/warden/jwt_auth/token_encoder_spec.rb
@@ -65,5 +65,18 @@ describe Warden::JWTAuth::TokenEncoder do
         expect(decoded_payload['foo']).to eq('bar')
       end
     end
+
+    context 'with issuer claim' do
+      let(:issuer) { 'http://example.com' }
+      before do
+        Warden::JWTAuth.configure do |config|
+          config.issuer = issuer
+        end
+      end
+
+      it 'adds a `iss` claim with the configured issuer' do
+        expect(decoded_payload['iss']).to eq(issuer)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

When an application needs to handle multiple JWT tokens issued by multiple issuers, this middleware gets in the way as it activates the warden strategy whenever a token is present in the authentication header.

This PR adds support for the [Issuer claim as specified in RFC 7519](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.1) and when configured verified that the `iss` claim matches before using the warden middleware.

With this, other warden strategies or middleware can authorize the JWT passed in the `Authorization` header.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [x] I have added automated tests to cover my changes.
- ~I have attached screenshots to demo visual changes.~
- ~I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- [x] I have updated the README to account for my changes.
