### PR TITLE
Add a hook method to user to be called before a JWT for the user has been dispatched

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,14 @@ def jwt_payload
 end
 ```
 
+Before a token is going to be dispatched to a client, a hook method `before_jwt_dispatch` is invoked, only when it exist, on the user record. This method takes the `request_params` (parameters comming from request) as arguments.
+
+```ruby
+def before_jwt_dispatch(request_params)
+  # Do something
+end
+```
+
 Just when a token is going to be dispatched to a client, a hook method `on_jwt_dispatch` is invoked, only when it exist, on the user record. This method takes the `token` and the `payload` as arguments.
 
 ```ruby

--- a/lib/warden/jwt_auth/hooks.rb
+++ b/lib/warden/jwt_auth/hooks.rb
@@ -25,7 +25,7 @@ module Warden
         scope = opts[:scope]
         return unless token_should_be_added?(scope, env)
 
-        add_token_to_env(user, scope, env)
+        add_token_to_env(user, scope, env, auth.params)
       end
 
       def token_should_be_added?(scope, env)
@@ -34,7 +34,8 @@ module Warden
         jwt_scope?(scope) && request_matches?(path_info, method)
       end
 
-      def add_token_to_env(user, scope, env)
+      def add_token_to_env(user, scope, env, request_params)
+        user.before_jwt_dispatch(request_params) if user.respond_to?(:before_jwt_dispatch)
         aud = EnvHelper.aud_header(env)
         token, payload = UserEncoder.new.call(user, scope, aud)
         user.on_jwt_dispatch(token, payload) if user.respond_to?(:on_jwt_dispatch)

--- a/lib/warden/jwt_auth/interfaces.rb
+++ b/lib/warden/jwt_auth/interfaces.rb
@@ -32,6 +32,13 @@ module Warden
           {}
         end
 
+        # Does something before a JWT for the user has been dispatched.
+        #
+        # @param _request_params [Hash]
+        def before_jwt_dispatch(_request_params)
+          raise NotImplementedError
+        end
+
         # Does something just after a JWT for the user has been dispatched.
         #
         # @param _token [String]

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -15,6 +15,10 @@ module Fixtures
       { 'foo' => 'bar' }
     end
 
+    def before_jwt_dispatch(request_params)
+      # Does something
+    end
+
     def on_jwt_dispatch(_token, _payload)
       # Does something
     end

--- a/spec/support/shared_contexts/feature.rb
+++ b/spec/support/shared_contexts/feature.rb
@@ -15,6 +15,7 @@ shared_context 'feature' do
   let(:success_response) { [200, {}, ['success']] }
 
   let(:pristine_env) { {} }
+  let(:env_with_rack_input) { { 'rack.input' => StringIO.new } }
 
   def build_app(app)
     builder = Rack::Builder.new

--- a/spec/warden/jwt_auth/features/token_dispatch_spec.rb
+++ b/spec/warden/jwt_auth/features/token_dispatch_spec.rb
@@ -25,7 +25,7 @@ describe 'Token dispatch', type: :feature do
 
   context 'when path and method match with configured' do
     it 'adds the token to Authorization response header' do
-      headers = call_app(signed_in_app, pristine_env, ['POST', '/sign_in'])[1]
+      headers = call_app(signed_in_app, env_with_rack_input, ['POST', '/sign_in'])[1]
 
       expect(headers).to have_key('Authorization')
     end

--- a/spec/warden/jwt_auth/hooks_spec.rb
+++ b/spec/warden/jwt_auth/hooks_spec.rb
@@ -44,6 +44,14 @@ describe Warden::JWTAuth::Hooks do
         expect(payload(last_request)['aud']).to eq('warden_tests')
       end
 
+      it 'calls before_jwt_dispatch method in the user' do
+        allow(user).to receive(:before_jwt_dispatch)
+
+        post '/sign_in'
+
+        expect(user).to have_received(:before_jwt_dispatch)
+      end
+
       it 'calls on_jwt_dispatch method in the user' do
         allow(user).to receive(:on_jwt_dispatch)
 


### PR DESCRIPTION
## Summary
<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if yuou do not have merge permissions on the repo, issues won't be auto-closed.
-->
Adds the hook method `before_jwt_dispatch` to be called before user encode to JWT token, passing the request params used on sign in.

This method can be usefull to set extra attributes to user, changing the return of `jwt_payload` for example.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [x] I have added automated tests to cover my changes.
- [ ] I have attached screenshots to demo visual changes.
- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- [x] I have updated the README to account for my changes.
