### PR TITLE
Prevent strategy from running when the current path matches a dispatc…

### DIFF
--- a/spec/warden/jwt_auth/strategy_spec.rb
+++ b/spec/warden/jwt_auth/strategy_spec.rb
@@ -15,7 +15,28 @@ describe Warden::JWTAuth::Strategy do
   describe '#valid?' do
     context 'when Authorization header is valid' do
       it 'returns true' do
-        env = { 'HTTP_AUTHORIZATION' => 'Bearer 123' }
+        env = { 'HTTP_AUTHORIZATION' => 'Bearer 123', 'PATH_INFO' => '/users', 'REQUEST_METHOD' => 'GET' }
+        strategy = described_class.new(env, :user)
+
+        expect(strategy).to be_valid
+      end
+
+      it 'returns false when the current path / method matches a dispatch request path / method' do
+        env = { 'HTTP_AUTHORIZATION' => 'Bearer 123', 'PATH_INFO' => '/sign_in', 'REQUEST_METHOD' => 'POST' }
+        strategy = described_class.new(env, :user)
+
+        expect(strategy).not_to be_valid
+      end
+
+      it 'returns true when the current path matches a dispatch request, but the method does not' do
+        env = { 'HTTP_AUTHORIZATION' => 'Bearer 123', 'PATH_INFO' => '/sign_in', 'REQUEST_METHOD' => 'GET' }
+        strategy = described_class.new(env, :user)
+
+        expect(strategy).to be_valid
+      end
+
+      it 'returns true when the current path does not match a dispatch request path' do
+        env = { 'HTTP_AUTHORIZATION' => 'Bearer 123', 'PATH_INFO' => '/users', 'REQUEST_METHOD' => 'POST' }
         strategy = described_class.new(env, :user)
 
         expect(strategy).to be_valid
@@ -25,6 +46,20 @@ describe Warden::JWTAuth::Strategy do
     context 'when Authorization header is not valid' do
       it 'returns false' do
         env = {}
+        strategy = described_class.new(env, :user)
+
+        expect(strategy).not_to be_valid
+      end
+
+      it 'returns false when the current path matches a dispatch request path' do
+        env = { 'PATH_INFO' => '/sign_in', 'REQUEST_METHOD' => 'POST' }
+        strategy = described_class.new(env, :user)
+
+        expect(strategy).not_to be_valid
+      end
+
+      it 'returns true when the current path does not match a dispatch request path' do
+        env = { 'PATH_INFO' => '/users', 'REQUEST_METHOD' => 'GET' }
         strategy = described_class.new(env, :user)
 
         expect(strategy).not_to be_valid


### PR DESCRIPTION
## Summary
As mentioned in the following issue https://github.com/waiting-for-dev/devise-jwt/issues/274, it is possible for a client to hit the sign in endpoint of an app with a valid token and obtain a fresh one, which would allow an attacker to infinitely extend the period of time they have access after stealing a token, without having to provide valid credentials.

This PR attempts to address that issue by preventing the strategy from running if our current path matches any of the token dispatch request paths. Presumably the desired behaviour here is for the request to carry on cascading through the strategy chain until it either passes or fails authentication. This means that if a client provides correct credentials **and** a token, it will fall through and still grant them a new one via the `after_set_user` hook.

I'm unsure if this warrants a readme update, please let me know if it does.
## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [x] I have added automated tests to cover my changes.
- [ ] I have attached screenshots to demo visual changes.
- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- [ ] I have updated the README to account for my changes.
