### PR TITLE
Relax the version requirement of the `jwt` gem

### DIFF
--- a/warden-jwt_auth.gemspec
+++ b/warden-jwt_auth.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'dry-auto_inject', '>= 0.8', '< 2'
   spec.add_dependency 'dry-configurable', '>= 0.13', '< 2'
-  spec.add_dependency 'jwt', '~> 2.1'
+  spec.add_dependency 'jwt', '>= 2.1', '< 4'
   spec.add_dependency 'warden', '~> 1.2'
 
   spec.add_development_dependency 'bundler'


### PR DESCRIPTION
Allow installing versions 3.x of the `jwt` gem.

Specs seemed to pass fine with all Ruby versions described at the testing matrix.

CHANGELOG of the `jwt` gem:
https://github.com/jwt/ruby-jwt/blob/main/CHANGELOG.md