### PR TITLE
Prevent token revocation from being replayed (#66)

### DIFF
--- a/lib/warden/jwt_auth/token_revoker.rb
+++ b/lib/warden/jwt_auth/token_revoker.rb
@@ -13,7 +13,10 @@ module Warden
         payload = TokenDecoder.new.call(token)
         scope = payload['scp'].to_sym
         user = PayloadUserHelper.find_user(payload)
-        revocation_strategies[scope].revoke_jwt(payload, user)
+        strategy = revocation_strategies[scope]
+        return if strategy.jwt_revoked?(payload, user)
+
+        strategy.revoke_jwt(payload, user)
       # rubocop:disable Lint/SuppressedException
       rescue JWT::ExpiredSignature
       end

--- a/spec/warden/jwt_auth/token_revoker_spec.rb
+++ b/spec/warden/jwt_auth/token_revoker_spec.rb
@@ -36,5 +36,25 @@ describe Warden::JWTAuth::TokenRevoker do
         expect { described_class.new.call(token) }.not_to raise_error
       end
     end
+
+    context 'when the token has already been revoked' do
+      before { described_class.new.call(token) }
+
+      it 'does not revoke it a second time' do
+        described_class.new.call(token)
+
+        expect(revocation_strategy.revoked.length).to eq(1)
+      end
+    end
+
+    context 'when the user encoded in the token no longer exists' do
+      before { Warden::JWTAuth.config.mappings = { user: Fixtures::NilUserRepo } }
+
+      it 'still revokes the token' do
+        described_class.new.call(token)
+
+        expect(revocation_strategy.revoked.length).to eq(1)
+      end
+    end
   end
 end


### PR DESCRIPTION
### Summary
This is an attempt to address the possibility of replaying token revocation with a token that has not yet expired, but has previously been revoked.

The issue mentioned the following:

>The helper method `PayloadUserHelper.find_user` also does not check for revocation.

I gave this some thought and decided that its not right for revocation logic to live in there. Given that it is a shared lookup helper used in both the authentication _and_ revocation paths, it doesn't make sense to overload it with an additional concern that only some callers want. The authentication path already handles revoked tokens by raising and with the changes I am proposing, the revocation path now prevents replays by skipping `revoke_jwt` (it doesn't make sense to raise a `Errors::RevokedToken` here as the HTTP response has already been decided).

One thing that might be worthy of consideration / discussion when adding a check during revocation is the following scenario:

```ruby
def jwt_revoked?(_payload, user)
  user.banned?  # true because the account has been banned
end

def revoke_jwt(payload, _user)
  Denylist.create!(jti: payload['jti']) # writes to a totally separate place
end
```

Granted, this is contrived, but the changes I am proposing introduce the assumption that `jwt_revoked?` is only going to return `true` for tokens that have been through revocation already. In the example above, that assumption would be wrong and the token would never make it to the `DenyList`. I'm not really sure how we could prevent replays without making that assumption though.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [x] I have added automated tests to cover my changes.
~~- [ ] I have attached screenshots to demo visual changes.~~
~~- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~~
~~- [ ] I have updated the README to account for my changes.~~
